### PR TITLE
chore: bump @typed-mxgraph/typed-mxgraph from 0.0.6 to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",
         "@rollup/plugin-node-resolve": "^13.1.3",
-        "@typed-mxgraph/typed-mxgraph": "^0.0.6",
+        "@typed-mxgraph/typed-mxgraph": "^1.0.5",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.70.1",
         "rollup-plugin-terser": "^7.0.2",
@@ -112,13 +112,10 @@
       "dev": true
     },
     "node_modules/@typed-mxgraph/typed-mxgraph": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-0.0.6.tgz",
-      "integrity": "sha512-ZqQLwS8wFRG/t5/XB+Awc+/vk0WIErv/KCQRhRLcJQdRsdmLUv/Uw29s6GWOi4IB7nY9ad1xT1RFs95rHGtINg==",
-      "dev": true,
-      "peerDependencies": {
-        "mxgraph": "^4.2.0"
-      }
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.5.tgz",
+      "integrity": "sha512-yJAFy5wLFmImBLAAUPtlnoN4r6JSnwM3466ubdaL5accJOmrHZ5gwGTZFNc7zAMtxfDN8sbEkNND3tZRilcRWg==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -2065,11 +2062,10 @@
       }
     },
     "@typed-mxgraph/typed-mxgraph": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-0.0.6.tgz",
-      "integrity": "sha512-ZqQLwS8wFRG/t5/XB+Awc+/vk0WIErv/KCQRhRLcJQdRsdmLUv/Uw29s6GWOi4IB7nY9ad1xT1RFs95rHGtINg==",
-      "dev": true,
-      "requires": {}
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.5.tgz",
+      "integrity": "sha512-yJAFy5wLFmImBLAAUPtlnoN4r6JSnwM3466ubdaL5accJOmrHZ5gwGTZFNc7zAMtxfDN8sbEkNND3tZRilcRWg==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "@typed-mxgraph/typed-mxgraph": "^0.0.6",
+    "@typed-mxgraph/typed-mxgraph": "^1.0.5",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.70.1",
     "rollup-plugin-typescript": "^1.0.1",

--- a/src/custom-shapes.ts
+++ b/src/custom-shapes.ts
@@ -1,5 +1,5 @@
 import mx from './mxgraph-loader';
-import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph';
+import type { mxAbstractCanvas2D, mxRectangle } from 'mxgraph';
 
 export function registerCustomShapes(): void {
     console.info('Registering custom shapes...');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import mx from './mxgraph-loader';
 import {registerCustomShapes} from "./custom-shapes";
-import {mxGraph, mxGraphModel} from 'mxgraph';
+import type {mxGraph, mxGraphModel} from 'mxgraph';
 
 // even though Rollup is bundling all your files together, errors and
 // logs will still point to your original source modules

--- a/src/mxgraph-loader.ts
+++ b/src/mxgraph-loader.ts
@@ -1,4 +1,4 @@
-import factory, {mxGraphExportObject} from 'mxgraph';
+import factory, {type mxGraphExportObject} from 'mxgraph';
 
 export default initialize();
 


### PR DESCRIPTION
Also import mxgraph types with the 'type' keyword to make things more explicit.