### PR TITLE
refactor: improve mxGraph initialization

### DIFF
--- a/src/mxgraph-loader.ts
+++ b/src/mxgraph-loader.ts
@@ -2,12 +2,24 @@ import factory, {type mxGraphExportObject} from 'mxgraph';
 
 export default initialize();
 
+// mxGraph globals
+declare global {
+  interface Window {
+    mxForceIncludes: boolean;
+    mxLoadResources: boolean;
+    mxLoadStylesheets: boolean;
+    mxResourceExtension: string;
+  }
+}
+
 function initialize(): mxGraphExportObject {
     // set options globally, as it is not working when passing options to the factory (https://github.com/jgraph/mxgraph/issues/479)
-    (window as any)['mxLoadResources'] = false;
-    (window as any)['mxLoadStylesheets'] = false;
-    // extras, otherwise we got 'Uncaught ReferenceError: assignment to undeclared variable mxForceIncludes'
-    (window as any)['mxForceIncludes'] = false;
-    (window as any)['mxResourceExtension'] = '.txt';
+    // Required otherwise 'Uncaught ReferenceError: assignment to undeclared variable mx...'
+    window.mxForceIncludes = false;
+    window.mxLoadResources = false;
+    // Required otherwise we got 'Uncaught ReferenceError: assignment to undeclared variable mx...'
+    window.mxLoadStylesheets = false;
+    window.mxResourceExtension = '.txt';
+
     return factory({});
 }


### PR DESCRIPTION
Avoid `any` when possible and better explain why we use `globals` instead of mxGraph options.

Based on feedback from https://github.com/typed-mxgraph/typed-mxgraph/issues/50